### PR TITLE
Change 'require' priority in the oauth_nonce_test.rb template

### DIFF
--- a/generators/oauth_provider/templates/oauth_nonce_test.rb
+++ b/generators/oauth_provider/templates/oauth_nonce_test.rb
@@ -1,5 +1,5 @@
-require 'oauth/helper'
 require File.dirname(__FILE__) + '/../test_helper'
+require 'oauth/helper'
 
 class ClientNoneTest < ActiveSupport::TestCase
   include OAuth::Helper


### PR DESCRIPTION
The test file created by the provider generator fails to be run. The reason for it that 'oauth/helper' is required before the main test helper. In consequence the 'oauth/helper' cannot be found. I think the main test helper should be required first.
