### PR TITLE
Fixed wrong generator name

### DIFF
--- a/lib/generators/active_record/oauth_consumer_generator.rb
+++ b/lib/generators/active_record/oauth_consumer_generator.rb
@@ -2,7 +2,7 @@ require 'rails/generators/active_record'
 
 module ActiveRecord
   module Generators
-    class OauthProviderGenerator < Rails::Generators::Base
+    class OauthConsumerGenerator < Rails::Generators::Base
       include Rails::Generators::Migration
 
       source_root File.expand_path('../oauth_consumer_templates', __FILE__)


### PR DESCRIPTION
Just a typo but it prevents from using a rails app with OAuth consumer and active_record ORM
