### PR TITLE
request_url -> request_uri

### DIFF
--- a/generators/oauth_provider/templates/controller_spec.rb
+++ b/generators/oauth_provider/templates/controller_spec.rb
@@ -143,7 +143,7 @@ describe OauthController do
 
     describe "authorize redirect" do
       before(:each) do
-        get :authorize, :response_type=>"code",:client_id=>current_client_application.key, :redirect_url=>"http://application/callback"
+        get :authorize, :response_type=>"code",:client_id=>current_client_application.key, :redirect_uri=>"http://application/callback"
       end
       
       it "should render authorize" do
@@ -157,7 +157,7 @@ describe OauthController do
     
     describe "authorize" do
       before(:each) do
-        post :authorize, :response_type=>"code",:client_id=>current_client_application.key, :redirect_url=>"http://application/callback",:authorize=>1
+        post :authorize, :response_type=>"code",:client_id=>current_client_application.key, :redirect_uri=>"http://application/callback",:authorize=>1
         @verification_token = Oauth2Verifier.last
         @oauth2_token_count= Oauth2Token.count
       end
@@ -179,7 +179,7 @@ describe OauthController do
       
       describe "get token" do
         before(:each) do
-          post :token, :grant_type=>"authorization_code", :client_id=>current_client_application.key,:client_secret=>current_client_application.secret, :redirect_url=>"http://application/callback",:code=>@verification_token.code
+          post :token, :grant_type=>"authorization_code", :client_id=>current_client_application.key,:client_secret=>current_client_application.secret, :redirect_uri=>"http://application/callback",:code=>@verification_token.code
           @token = Oauth2Token.last
         end
         
@@ -202,7 +202,7 @@ describe OauthController do
 
       describe "get token with wrong secret" do
         before(:each) do
-          post :token, :grant_type=>"authorization_code", :client_id=>current_client_application.key,:client_secret=>"fake", :redirect_url=>"http://application/callback",:code=>@verification_token.code
+          post :token, :grant_type=>"authorization_code", :client_id=>current_client_application.key,:client_secret=>"fake", :redirect_uri=>"http://application/callback",:code=>@verification_token.code
         end
         
         it "should not create token" do
@@ -216,7 +216,7 @@ describe OauthController do
       
       describe "get token with wrong code" do
         before(:each) do
-          post :token, :grant_type=>"authorization_code", :client_id=>current_client_application.key,:client_secret=>current_client_application.secret, :redirect_url=>"http://application/callback",:code=>"fake"
+          post :token, :grant_type=>"authorization_code", :client_id=>current_client_application.key,:client_secret=>current_client_application.secret, :redirect_uri=>"http://application/callback",:code=>"fake"
         end
 
         it "should not create token" do
@@ -228,9 +228,9 @@ describe OauthController do
         end
       end
 
-      describe "get token with wrong redirect_url" do
+      describe "get token with wrong redirect_uri" do
         before(:each) do
-          post :token, :grant_type=>"authorization_code", :client_id=>current_client_application.key,:client_secret=>current_client_application.secret, :redirect_url=>"http://evil/callback",:code=>@verification_token.code
+          post :token, :grant_type=>"authorization_code", :client_id=>current_client_application.key,:client_secret=>current_client_application.secret, :redirect_uri=>"http://evil/callback",:code=>@verification_token.code
         end
 
         it "should not create token" do
@@ -246,7 +246,7 @@ describe OauthController do
 
     describe "deny" do
       before(:each) do
-        post :authorize, :response_type=>"code", :client_id=>current_client_application.key, :redirect_url=>"http://application/callback",:authorize=>0
+        post :authorize, :response_type=>"code", :client_id=>current_client_application.key, :redirect_uri=>"http://application/callback",:authorize=>0
       end
 
       it { Oauth2Verifier.last.should be_nil }
@@ -269,7 +269,7 @@ describe OauthController do
 
     describe "authorize redirect" do
       before(:each) do
-        get :authorize, :response_type=>"token",:client_id=>current_client_application.key, :redirect_url=>"http://application/callback"
+        get :authorize, :response_type=>"token",:client_id=>current_client_application.key, :redirect_uri=>"http://application/callback"
       end
 
       it "should render authorize" do
@@ -283,7 +283,7 @@ describe OauthController do
 
     describe "authorize" do
       before(:each) do
-        post :authorize, :response_type=>"token",:client_id=>current_client_application.key, :redirect_url=>"http://application/callback",:authorize=>1
+        post :authorize, :response_type=>"token",:client_id=>current_client_application.key, :redirect_uri=>"http://application/callback",:authorize=>1
         @token = Oauth2Token.last
       end
       subject { @token }
@@ -309,7 +309,7 @@ describe OauthController do
     
     describe "deny" do
       before(:each) do
-        post :authorize, :response_type=>"token", :client_id=>current_client_application.key, :redirect_url=>"http://application/callback",:authorize=>0
+        post :authorize, :response_type=>"token", :client_id=>current_client_application.key, :redirect_uri=>"http://application/callback",:authorize=>0
       end
       
       it { Oauth2Verifier.last.should be_nil }

--- a/generators/oauth_provider/templates/oauth2_authorize.html.erb
+++ b/generators/oauth_provider/templates/oauth2_authorize.html.erb
@@ -3,7 +3,7 @@
 <%% form_tag authorize_url do %>
   <%%= hidden_field_tag "response_type", params[:response_type]%>
   <%%= hidden_field_tag "client_id", params[:client_id]%>
-  <%%= hidden_field_tag "redirect_url", params[:redirect_url]%>
+  <%%= hidden_field_tag "redirect_uri", params[:redirect_uri]%>
   <%%= hidden_field_tag "state", params[:state]%>
   <%%= hidden_field_tag "scope", params[:scope]%>
   

--- a/generators/oauth_provider/templates/oauth2_authorize.html.haml
+++ b/generators/oauth_provider/templates/oauth2_authorize.html.haml
@@ -8,7 +8,7 @@
 - form_tag authorize_url do
   = hidden_field_tag "response_type", params[:response_type]
   = hidden_field_tag "client_id", params[:client_id]
-  = hidden_field_tag "redirect_url", params[:redirect_url]
+  = hidden_field_tag "redirect_uri", params[:redirect_uri]
   = hidden_field_tag "state", params[:state]
   = hidden_field_tag "scope", params[:scope]
   = check_box_tag 'authorize'

--- a/lib/generators/erb/oauth_provider_templates/oauth2_authorize.html.erb
+++ b/lib/generators/erb/oauth_provider_templates/oauth2_authorize.html.erb
@@ -3,7 +3,7 @@
 <%% form_tag authorize_url do %>
   <%%= hidden_field_tag "response_type", params[:response_type]%>
   <%%= hidden_field_tag "client_id", params[:client_id]%>
-  <%%= hidden_field_tag "redirect_url", params[:redirect_url]%>
+  <%%= hidden_field_tag "redirect_uri", params[:redirect_uri]%>
   <%%= hidden_field_tag "state", params[:state]%>
   <%%= hidden_field_tag "scope", params[:scope]%>
 

--- a/lib/generators/haml/oauth_provider_templates/oauth2_authorize.html.haml
+++ b/lib/generators/haml/oauth_provider_templates/oauth2_authorize.html.haml
@@ -8,7 +8,7 @@
 - form_tag authorize_url do
   = hidden_field_tag "response_type", params[:response_type]
   = hidden_field_tag "client_id", params[:client_id]
-  = hidden_field_tag "redirect_url", params[:redirect_url]
+  = hidden_field_tag "redirect_uri", params[:redirect_uri]
   = hidden_field_tag "state", params[:state]
   = hidden_field_tag "scope", params[:scope]
   = check_box_tag 'authorize'

--- a/lib/generators/rspec/templates/controller_spec.rb
+++ b/lib/generators/rspec/templates/controller_spec.rb
@@ -143,7 +143,7 @@ describe OauthController do
 
     describe "authorize redirect" do
       before(:each) do
-        get :authorize, :response_type=>"code",:client_id=>current_client_application.key, :redirect_url=>"http://application/callback"
+        get :authorize, :response_type=>"code",:client_id=>current_client_application.key, :redirect_uri=>"http://application/callback"
       end
 
       it "should render authorize" do
@@ -157,7 +157,7 @@ describe OauthController do
 
     describe "authorize" do
       before(:each) do
-        post :authorize, :response_type=>"code",:client_id=>current_client_application.key, :redirect_url=>"http://application/callback",:authorize=>"1"
+        post :authorize, :response_type=>"code",:client_id=>current_client_application.key, :redirect_uri=>"http://application/callback",:authorize=>"1"
         @verification_token = Oauth2Verifier.last
         @oauth2_token_count= Oauth2Token.count
       end
@@ -179,7 +179,7 @@ describe OauthController do
 
       describe "get token" do
         before(:each) do
-          post :token, :grant_type=>"authorization_code", :client_id=>current_client_application.key,:client_secret=>current_client_application.secret, :redirect_url=>"http://application/callback",:code=>@verification_token.code
+          post :token, :grant_type=>"authorization_code", :client_id=>current_client_application.key,:client_secret=>current_client_application.secret, :redirect_uri=>"http://application/callback",:code=>@verification_token.code
           @token = Oauth2Token.last
         end
 
@@ -202,7 +202,7 @@ describe OauthController do
 
       describe "get token with wrong secret" do
         before(:each) do
-          post :token, :grant_type=>"authorization_code", :client_id=>current_client_application.key,:client_secret=>"fake", :redirect_url=>"http://application/callback",:code=>@verification_token.code
+          post :token, :grant_type=>"authorization_code", :client_id=>current_client_application.key,:client_secret=>"fake", :redirect_uri=>"http://application/callback",:code=>@verification_token.code
         end
 
         it "should not create token" do
@@ -216,7 +216,7 @@ describe OauthController do
 
       describe "get token with wrong code" do
         before(:each) do
-          post :token, :grant_type=>"authorization_code", :client_id=>current_client_application.key,:client_secret=>current_client_application.secret, :redirect_url=>"http://application/callback",:code=>"fake"
+          post :token, :grant_type=>"authorization_code", :client_id=>current_client_application.key,:client_secret=>current_client_application.secret, :redirect_uri=>"http://application/callback",:code=>"fake"
         end
 
         it "should not create token" do
@@ -228,9 +228,9 @@ describe OauthController do
         end
       end
 
-      describe "get token with wrong redirect_url" do
+      describe "get token with wrong redirect_uri" do
         before(:each) do
-          post :token, :grant_type=>"authorization_code", :client_id=>current_client_application.key,:client_secret=>current_client_application.secret, :redirect_url=>"http://evil/callback",:code=>@verification_token.code
+          post :token, :grant_type=>"authorization_code", :client_id=>current_client_application.key,:client_secret=>current_client_application.secret, :redirect_uri=>"http://evil/callback",:code=>@verification_token.code
         end
 
         it "should not create token" do
@@ -246,7 +246,7 @@ describe OauthController do
 
     describe "deny" do
       before(:each) do
-        post :authorize, :response_type=>"code", :client_id=>current_client_application.key, :redirect_url=>"http://application/callback",:authorize=>"0"
+        post :authorize, :response_type=>"code", :client_id=>current_client_application.key, :redirect_uri=>"http://application/callback",:authorize=>"0"
       end
 
       it { Oauth2Verifier.last.should be_nil }
@@ -269,7 +269,7 @@ describe OauthController do
 
     describe "authorize redirect" do
       before(:each) do
-        get :authorize, :response_type=>"token",:client_id=>current_client_application.key, :redirect_url=>"http://application/callback"
+        get :authorize, :response_type=>"token",:client_id=>current_client_application.key, :redirect_uri=>"http://application/callback"
       end
 
       it "should render authorize" do
@@ -283,7 +283,7 @@ describe OauthController do
 
     describe "authorize" do
       before(:each) do
-        post :authorize, :response_type=>"token",:client_id=>current_client_application.key, :redirect_url=>"http://application/callback",:authorize=>"1"
+        post :authorize, :response_type=>"token",:client_id=>current_client_application.key, :redirect_uri=>"http://application/callback",:authorize=>"1"
         @token = Oauth2Token.last
       end
       subject { @token }
@@ -309,7 +309,7 @@ describe OauthController do
 
     describe "deny" do
       before(:each) do
-        post :authorize, :response_type=>"token", :client_id=>current_client_application.key, :redirect_url=>"http://application/callback",:authorize=>"0"
+        post :authorize, :response_type=>"token", :client_id=>current_client_application.key, :redirect_uri=>"http://application/callback",:authorize=>"0"
       end
 
       it { Oauth2Verifier.last.should be_nil }

--- a/lib/oauth/controllers/provider_controller.rb
+++ b/lib/oauth/controllers/provider_controller.rb
@@ -121,7 +121,7 @@ module OAuth
       def oauth2_authorize_code
         @client_application = ClientApplication.find_by_key params[:client_id]
         if request.post?
-          @redirect_url = URI.parse(params[:redirect_url] || @client_application.callback_url)
+          @redirect_url = URI.parse(params[:redirect_uri] || @client_application.callback_url)
           if user_authorizes_token?
             @verification_code = Oauth2Verifier.create :client_application=>@client_application, :user=>current_user, :callback_url=>@redirect_url.to_s
 
@@ -151,7 +151,7 @@ module OAuth
       def oauth2_authorize_token
         @client_application = ClientApplication.find_by_key params[:client_id]
         if request.post?
-          @redirect_url = URI.parse(params[:redirect_url] || @client_application.callback_url)
+          @redirect_url = URI.parse(params[:redirect_uri] || @client_application.callback_url)
           if user_authorizes_token?
             @token  = Oauth2Token.create :client_application=>@client_application, :user=>current_user, :scope=>params[:scope]
             unless @redirect_url.to_s.blank?
@@ -184,7 +184,7 @@ module OAuth
           oauth2_error
           return
         end
-        if @verification_code.redirect_url != params[:redirect_url]
+        if @verification_code.redirect_url != params[:redirect_uri]
           oauth2_error
           return
         end


### PR DESCRIPTION
Hi,

I've changed the callback parameter from redirect_urL to redirect_urI since that is what the OAuth2 spec calls for. Example: http://tools.ietf.org/html/draft-ietf-oauth-v2-11#section-5.1.1

I had some trouble running the generated tests, so I'll admit that I haven't checked that they all run properly. But I have tested the functionality manually and it seems to be working as it should, redirecting properly.

Cheers
Kim
