### PR TITLE
Oauthenticate filter fix

### DIFF
--- a/lib/oauth/controllers/application_controller_methods.rb
+++ b/lib/oauth/controllers/application_controller_methods.rb
@@ -29,7 +29,7 @@ module OAuth
           @strategies << :interactive if @options[:interactive]
         end
         
-        def filter(controller)
+        def self.filter(controller)
           Authenticator.new(controller,@strategies).allow?
         end
       end


### PR DESCRIPTION
The oauthenticate filter wasn't executing as expected. The #filter method needs to be defined in class scope.

Cheers
Kim
