### PR TITLE
Response type token

### DIFF
--- a/lib/generators/rspec/templates/controller_spec.rb
+++ b/lib/generators/rspec/templates/controller_spec.rb
@@ -289,7 +289,7 @@ describe OauthController do
       subject { @token }
       it "should redirect to default callback" do
         response.should be_redirect
-        response.should redirect_to("http://application/callback?access_token=#{@token.token}")
+        response.should redirect_to("http://application/callback#access_token=#{@token.token}")
       end
 
       it "should not have a scope" do

--- a/lib/oauth/controllers/provider_controller.rb
+++ b/lib/oauth/controllers/provider_controller.rb
@@ -155,10 +155,7 @@ module OAuth
           if user_authorizes_token?
             @token  = Oauth2Token.create :client_application=>@client_application, :user=>current_user, :scope=>params[:scope]
             unless @redirect_url.to_s.blank?
-              @redirect_url.query = @redirect_url.query.blank? ?
-                                    "access_token=#{@token.token}" :
-                                    @redirect_url.query + "&access_token=#{@token.token}"
-              redirect_to @redirect_url.to_s
+              redirect_to "#{@redirect_url.to_s}#access_token=#{@token.token}"
             else
               render :action => "authorize_success"
             end


### PR DESCRIPTION
Hey,

I have fixed a small issue with oauth2_authorize_token, it was incorrectly redirecting to ?access_token=X, but the draft 10 spec calls for #access_token=X

Cheers
Kim
