### PR TITLE
handle requestTokens registered without callback_url properly

### DIFF
--- a/generators/oauth_provider/templates/request_token.rb
+++ b/generators/oauth_provider/templates/request_token.rb
@@ -30,7 +30,7 @@ class RequestToken < OauthToken
   end
   
   def oob?
-    self.callback_url=='oob'
+    callback_url.nil? || callback_url.downcase == 'oob'
   end
   
   def oauth10?


### PR DESCRIPTION
Some OAuth libraries (such as the Python library) do not properly send the callback_url or misspell "oob" as "OOB". This change acts as expected in those cases.
