### PR TITLE
Fix assignment of type for ConsumerToken subclasses

### DIFF
--- a/lib/oauth/models/consumers/token.rb
+++ b/lib/oauth/models/consumers/token.rb
@@ -40,15 +40,14 @@ module Oauth
           
           def find_or_create_from_access_token(user,access_token)
             if user
-              token = self.find_or_create_by_user_id_and_token(user.id, access_token.token)
+              token = self.find_or_initialize_by_user_id_and_token(user.id, access_token.token)
             else
-              token = self.find_or_create_by_token(access_token.token)
+              token = self.find_or_initialize_by_token(access_token.token)
             end
             
-            if token.new_record?
-              token.secret = access_token.secret
-              token.save
-            end
+            # set or update the secret
+            token.secret = access_token.secret
+            token.save!
 
             token
           end

--- a/lib/oauth/models/consumers/token.rb
+++ b/lib/oauth/models/consumers/token.rb
@@ -40,12 +40,17 @@ module Oauth
           
           def find_or_create_from_access_token(user,access_token)
             if user
-              user.consumer_tokens.first(:conditions=>{:type=>self.to_s,:token=>access_token.token}) ||
-                user.consumer_tokens.create!(:type=>self.to_s,:token=>access_token.token, :secret=>access_token.secret)
+              token = self.find_or_create_by_user_id_and_token(user.id, access_token.token)
             else
-              ConsumerToken.first( :conditions =>{ :token=>access_token.token,:type=>self.to_s}) ||
-                create(:type=>self.to_s,:token=>access_token.token, :secret=>access_token.secret)
+              token = self.find_or_create_by_token(access_token.token)
             end
+            
+            if token.new_record?
+              token.secret = access_token.secret
+              token.save
+            end
+
+            token
           end
           
           def build_user_from_token


### PR DESCRIPTION
ActiveRecord (at least in Rails 3) doesn't allow you to set/query records on an explicit value for the `type` field.
