### PR TITLE
Pass OAuth query string to callback

### DIFF
--- a/lib/oauth/controllers/consumer_controller.rb
+++ b/lib/oauth/controllers/consumer_controller.rb
@@ -18,7 +18,8 @@ module Oauth
       # If user is already connected it displays a page with an option to disconnect and redo
       def show
         unless @token
-          @request_token=@consumer.get_request_token(callback_oauth_consumer_url(params[:id]))
+          request_url = callback_oauth_consumer_url(params[:id]) + '?' + request.query_string
+          @request_token=@consumer.get_request_token(request_url)
           session[@request_token.token]=@request_token.secret
           if @request_token.callback_confirmed?
             redirect_to @request_token.authorize_url


### PR DESCRIPTION
I want to keep some context of where my OAuth consumer request came from, so with this fix I can pass query params to /oauth_consumers/<service>, which will be appended to the callback URL.
