### PR TITLE
Fix Twitter gem compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,26 @@
 PATH
   remote: .
   specs:
-    oauth-plugin (0.4.0.pre4)
+    oauth-plugin (0.4.0.pre5)
       multi_json
       oauth (~> 0.4.4)
+      oauth2
       rack
+      twitter (~> 1.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    addressable (2.2.2)
+    addressable (2.2.4)
     configuration (1.2.0)
     diff-lcs (1.1.2)
     fakeweb (1.3.0)
-    faraday (0.5.4)
-      addressable (~> 2.2.2)
+    faraday (0.5.7)
+      addressable (~> 2.2.4)
       multipart-post (~> 1.1.0)
-      rack (>= 1.1.0, < 2)
-    faraday_middleware (0.3.1)
-      faraday (~> 0.5.3)
+      rack (< 2, >= 1.1.0)
+    faraday_middleware (0.3.2)
+      faraday (~> 0.5.4)
     fuubar (0.0.3)
       rspec (~> 2.0)
       rspec-instafail (~> 0.1.4)
@@ -29,7 +31,7 @@ GEM
       thor (~> 0.14.3)
     guard-rspec (0.1.9)
       guard (>= 0.2.2)
-    hashie (0.4.0)
+    hashie (1.0.0)
     launchy (0.3.7)
       configuration (>= 0.0.5)
       rake (>= 0.8.1)
@@ -37,6 +39,9 @@ GEM
     multi_xml (0.2.0)
     multipart-post (1.1.0)
     oauth (0.4.4)
+    oauth2 (0.1.1)
+      faraday (~> 0.5.0)
+      multi_json (~> 0.0.4)
     open_gem (1.4.2)
       launchy (~> 0.3.5)
     opentransact (0.1.0)
@@ -57,15 +62,15 @@ GEM
     rspec-instafail (0.1.5)
     rspec-mocks (2.4.0)
     ruby-progressbar (0.0.9)
-    simple_oauth (0.1.3)
+    simple_oauth (0.1.4)
     thor (0.14.6)
-    twitter (1.1.0)
-      faraday (~> 0.5.3)
-      faraday_middleware (~> 0.3.1)
-      hashie (~> 0.4.0)
+    twitter (1.2.0)
+      faraday (~> 0.5.4)
+      faraday_middleware (~> 0.3.2)
+      hashie (~> 1.0.0)
       multi_json (~> 0.0.5)
       multi_xml (~> 0.2.0)
-      simple_oauth (~> 0.1.3)
+      simple_oauth (~> 0.1.4)
 
 PLATFORMS
   ruby
@@ -75,11 +80,7 @@ DEPENDENCIES
   fuubar
   growl
   guard-rspec
-  multi_json
-  oauth (~> 0.4.4)
   oauth-plugin!
   opentransact
-  rack
   rack-test
   rspec (~> 2.4.0)
-  twitter

--- a/lib/oauth/models/consumers/services/twitter_token.rb
+++ b/lib/oauth/models/consumers/services/twitter_token.rb
@@ -6,12 +6,6 @@ class TwitterToken < ConsumerToken
   end
   
   def client
-    unless @client
-      @twitter_oauth=Twitter::OAuth.new TwitterToken.consumer.key,TwitterToken.consumer.secret
-      @twitter_oauth.authorize_from_access token,secret
-      @client=Twitter::Base.new(@twitter_oauth)
-    end
-    
-    @client
+    @client ||= Twitter::Client.new(:consumer_key => TwitterToken.consumer.key, :consumer_secret => TwitterToken.consumer.secret)
   end
 end

--- a/oauth-plugin.gemspec
+++ b/oauth-plugin.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.rubyforge_project = %q{oauth}
   s.rubygems_version = %q{1.3.7}
   s.summary = %q{Ruby on Rails Plugin for OAuth Provider and Consumer}
-  s.add_development_dependency "twitter"
   s.add_development_dependency "opentransact"
   s.add_development_dependency "rspec", "~> 2.4.0"
   s.add_development_dependency "fakeweb"
@@ -36,5 +35,6 @@ Gem::Specification.new do |s|
   s.add_dependency("oauth", ["~> 0.4.4"])
   s.add_dependency("rack")
   s.add_dependency("oauth2")
+  s.add_dependency "twitter", "~> 1.0"
 end
 


### PR DESCRIPTION
The Twitter gem has changed internally and TwitterToken#client was no longer functioning - though the Twitter gem doesn't use your oauth plugin, basic request methods work similarly.
