### PR TITLE
Add client endpoint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,6 @@ PATH
       oauth (~> 0.4.4)
       oauth2
       rack
-      twitter (~> 1.0)
 
 GEM
   remote: http://rubygems.org/
@@ -19,8 +18,6 @@ GEM
       addressable (~> 2.2.4)
       multipart-post (~> 1.1.0)
       rack (< 2, >= 1.1.0)
-    faraday_middleware (0.3.2)
-      faraday (~> 0.5.4)
     fuubar (0.0.3)
       rspec (~> 2.0)
       rspec-instafail (~> 0.1.4)
@@ -31,7 +28,6 @@ GEM
       thor (~> 0.14.3)
     guard-rspec (0.1.9)
       guard (>= 0.2.2)
-    hashie (1.0.0)
     launchy (0.3.7)
       configuration (>= 0.0.5)
       rake (>= 0.8.1)
@@ -62,15 +58,7 @@ GEM
     rspec-instafail (0.1.5)
     rspec-mocks (2.4.0)
     ruby-progressbar (0.0.9)
-    simple_oauth (0.1.4)
     thor (0.14.6)
-    twitter (1.2.0)
-      faraday (~> 0.5.4)
-      faraday_middleware (~> 0.3.2)
-      hashie (~> 1.0.0)
-      multi_json (~> 0.0.5)
-      multi_xml (~> 0.2.0)
-      simple_oauth (~> 0.1.4)
 
 PLATFORMS
   ruby

--- a/README.rdoc
+++ b/README.rdoc
@@ -404,9 +404,13 @@ Once the user has authorized your application, you can access the client APIs vi
 
   /oauth_consumers/[SERVICE_NAME]/client/[ENDPOINT]
 
-For example to get the user's Google Calendars (which is available at "https://www.google.com/calendar/feeds/default?alt=jsonc"), you would append that path as the ENDPOINT above, i.e.
+For example to get the user's Google Calendars in JSON (documented in their API as "https://www.google.com/calendar/feeds/default?alt=jsonc"), you would append that path as the ENDPOINT above, i.e.
 
-  /oauth_consumers/[SERVICE_NAME]/client/calendar/feeds/default?alt=jsonc
+  /oauth_consumers/google/client/calendar/feeds/default?alt=jsonc
+
+As another example, to get my Twitter info as XML (available at "https://api.twitter.com/1/users/show.xml?screen_name=pelleb"), use:
+
+  /oauth_consumers/twitter/client/1/users/show.xml?screen_name=pelleb
 
 === Migrate database
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -400,6 +400,14 @@ Where SERVICE_NAME is the name you set in the OAUTH_CREDENTIALS hash. This will 
   
 You can specify this url to the service you're calling when you register, but it will automatically be sent along anyway.
 
+Once the user has authorized your application, you can access the client APIs via:
+
+  /oauth_consumers/[SERVICE_NAME]/client/[ENDPOINT]
+
+For example to get the user's Google Calendars (which is available at "https://www.google.com/calendar/feeds/default?alt=jsonc"), you would append that path as the ENDPOINT above, i.e.
+
+  /oauth_consumers/[SERVICE_NAME]/client/calendar/feeds/default?alt=jsonc
+
 === Migrate database
 
 The database is defined in:

--- a/generators/oauth_consumer/templates/controller.rb
+++ b/generators/oauth_consumer/templates/controller.rb
@@ -10,6 +10,10 @@ class OauthConsumersController < ApplicationController
   def callback
     super
   end
+
+  def client
+    super
+  end
   
   protected
   

--- a/lib/generators/oauth_consumer/oauth_consumer_generator.rb
+++ b/lib/generators/oauth_consumer/oauth_consumer_generator.rb
@@ -22,6 +22,7 @@ resources :oauth_consumers do
     member do
       get :callback
       get :callback2
+      match 'client/*endpoint' => 'oauth_consumers#client'
     end
   end
 ROUTE

--- a/lib/oauth/controllers/consumer_controller.rb
+++ b/lib/oauth/controllers/consumer_controller.rb
@@ -77,20 +77,17 @@ module Oauth
       end
 
       def client
-        # TODO handle format
-        options = params.except :id, :endpoint, :action, :controller
         method = request.method.downcase.to_sym
-        path = '/' + params[:endpoint]
+        path = "/#{params[:endpoint]}?#{request.query_string}"
 
         if @token
-          oauth_response = @token.client.send(method, path, options)
+          oauth_response = @token.client.send(method, path)
           if oauth_response.is_a? Net::HTTPRedirection
             # follow redirect
-            oauth_response = @token.client.send(method, oauth_response['Location']) # pass options?
+            oauth_response = @token.client.send(method, oauth_response['Location'])
           end
 
-          output = oauth_response.is_a?(Hashie::Mash) ? oauth_response.to_json : oauth_response.body
-          render :text => output
+          render :text => oauth_response.body
         else
           render :text => "Token needed.", :status => 403
         end

--- a/lib/oauth/controllers/consumer_controller.rb
+++ b/lib/oauth/controllers/consumer_controller.rb
@@ -76,6 +76,26 @@ module Oauth
 
       end
 
+      def client
+        # TODO handle format
+        options = params.except :id, :endpoint, :action, :controller
+        method = request.method.downcase.to_sym
+        path = '/' + params[:endpoint]
+
+        if @token
+          oauth_response = @token.client.send(method, path, options)
+          if oauth_response.is_a? Net::HTTPRedirection
+            # follow redirect
+            oauth_response = @token.client.send(method, oauth_response['Location']) # pass options?
+          end
+
+          output = oauth_response.is_a?(Hashie::Mash) ? oauth_response.to_json : oauth_response.body
+          render :text => output
+        else
+          render :text => "Token needed.", :status => 403
+        end
+      end
+
       def destroy
         throw RecordNotFound unless @token
         @token.destroy

--- a/lib/oauth/models/consumers/services/twitter_token.rb
+++ b/lib/oauth/models/consumers/services/twitter_token.rb
@@ -1,11 +1,12 @@
-require 'twitter'
 class TwitterToken < ConsumerToken
-  TWITTER_SETTINGS={:site=>"http://twitter.com"}
-  def self.consumer
-    @consumer||=OAuth::Consumer.new credentials[:key],credentials[:secret],TWITTER_SETTINGS
-  end
+  TWITTER_SETTINGS={
+    :site => "https://api.twitter.com",
+    :request_token_path => "/oauth/request_token",
+    :authorize_path => "/oauth/authorize",
+    :access_token_path => "/oauth/access_token",
+  }
   
-  def client
-    @client ||= Twitter::Client.new(:consumer_key => TwitterToken.consumer.key, :consumer_secret => TwitterToken.consumer.secret)
+  def self.consumer(options={})
+    @consumer ||= OAuth::Consumer.new(credentials[:key], credentials[:secret], TWITTER_SETTINGS.merge(options))
   end
 end

--- a/oauth-plugin.gemspec
+++ b/oauth-plugin.gemspec
@@ -35,6 +35,5 @@ Gem::Specification.new do |s|
   s.add_dependency("oauth", ["~> 0.4.4"])
   s.add_dependency("rack")
   s.add_dependency("oauth2")
-  s.add_dependency "twitter", "~> 1.2.0"
 end
 


### PR DESCRIPTION
With your nice work adding a client to the Token, it is now trivial to create an endpoint for arbitrary API endpoints.  Note, this did not work so well with the Twitter gem integration that I did earlier, so I modified that token to be more generic.

As an example, here is a how to access your Google Calendars:

```
/oauth_consumers/google/client/calendar/feeds/default?alt=jsonc
```

and here is how to access a Twitter user:

```
/oauth_consumers/twitter/client/1/users/show.json?screen_name=aidanfeldman
```

Basically, it works with `/oauth_consumers/SERVICE/client/`, followed by the path of the desired API endpoint with any arbitrary extension or query params.

Please let me know if you see any cases where this doesn't work.
