### PR TITLE
Force removal of existing token

### DIFF
--- a/lib/oauth/controllers/consumer_controller.rb
+++ b/lib/oauth/controllers/consumer_controller.rb
@@ -14,10 +14,11 @@ module Oauth
         @services=OAUTH_CREDENTIALS.keys-@consumer_tokens.collect{|c| c.class.service_name}
       end      
       
-      # creates request token and redirects on to oauth provider's auth page
-      # If user is already connected it displays a page with an option to disconnect and redo
+      # If the user has no token or <tt>force</tt> is set as a param, creates request token and
+      # redirects on to oauth provider's auth page.  Otherwise it displays a page with an option
+      # to disconnect and redo
       def show
-        unless @token
+        unless @token || params[:force]
           if @consumer.ancestors.include?(Oauth2Token)
             request_url = callback2_oauth_consumer_url(params[:id]) + '?' + request.query_string
             redirect_to @consumer.authorize_url(request_url)

--- a/lib/oauth/controllers/consumer_controller.rb
+++ b/lib/oauth/controllers/consumer_controller.rb
@@ -18,7 +18,12 @@ module Oauth
       # redirects on to oauth provider's auth page.  Otherwise it displays a page with an option
       # to disconnect and redo
       def show
-        if @token.nil? || params[:force]
+        if @token && params[:force]
+          @token.destroy
+          @token = nil
+        end
+
+        unless @token
           if @consumer.ancestors.include?(Oauth2Token)
             request_url = callback2_oauth_consumer_url(params[:id]) + '?' + request.query_string
             redirect_to @consumer.authorize_url(request_url)

--- a/lib/oauth/controllers/consumer_controller.rb
+++ b/lib/oauth/controllers/consumer_controller.rb
@@ -18,7 +18,7 @@ module Oauth
       # redirects on to oauth provider's auth page.  Otherwise it displays a page with an option
       # to disconnect and redo
       def show
-        unless @token || params[:force]
+        if @token.nil? || params[:force]
           if @consumer.ancestors.include?(Oauth2Token)
             request_url = callback2_oauth_consumer_url(params[:id]) + '?' + request.query_string
             redirect_to @consumer.authorize_url(request_url)


### PR DESCRIPTION
So I came across the issue where I was attempting an API but the user's token had either expired or they had unauthorized the app, but sending the user to the 'show' action would display the "you already have a token" page, rather than redirecting them to the service's auth page and getting a new token.

There are probably other ways to go about this, but my approach was to pass a `?force=1` query param to the request, which would delete the existing token.  Totally open to ideas about how to do this differently.
