### PR TITLE
If credentials[:options] is nil, then OAuth::Consumer gets passed a nil object when it expects a Hash. This causes ugly errors (tried to perform nil.inject, that sort of thing). I've added a nil guard here.

### DIFF
--- a/generators/oauth_consumer/templates/oauth_config.rb
+++ b/generators/oauth_consumer/templates/oauth_config.rb
@@ -25,7 +25,12 @@
 #   },
 #   :facebook => {
 #     :key => "",
-#     :secret => ""
+#     :secret => "",
+#     :oauth_version => 2,
+#     :super_class => 'Oauth2Token' # unnecessary if you have an explicit "class FacebookToken < Oauth2Token",
+#     :options => {
+#       :site => "https://graph.facebook.com"
+#     }
 #   },
 #   :agree2 => {
 #     :key => "",

--- a/lib/oauth/models/consumers/token.rb
+++ b/lib/oauth/models/consumers/token.rb
@@ -22,6 +22,7 @@ module Oauth
           end
           
           def consumer
+            options = credentials[:options] || {}
             @consumer||=OAuth::Consumer.new credentials[:key],credentials[:secret],credentials[:options]
           end
 

--- a/lib/oauth/models/consumers/token.rb
+++ b/lib/oauth/models/consumers/token.rb
@@ -23,7 +23,7 @@ module Oauth
           
           def consumer
             options = credentials[:options] || {}
-            @consumer||=OAuth::Consumer.new credentials[:key],credentials[:secret],credentials[:options]
+            @consumer||=OAuth::Consumer.new credentials[:key],credentials[:secret],options
           end
 
           def get_request_token(callback_url)


### PR DESCRIPTION
If options is nil, pass an empty hash instead so OAuth::Consumer won't choke.
