### PR TITLE
Better Facebook sample.

### DIFF
--- a/generators/oauth_consumer/templates/oauth_config.rb
+++ b/generators/oauth_consumer/templates/oauth_config.rb
@@ -25,7 +25,12 @@
 #   },
 #   :facebook => {
 #     :key => "",
-#     :secret => ""
+#     :secret => "",
+#     :oauth_version => 2,
+#     :super_class => 'Oauth2Token' # unnecessary if you have an explicit "class FacebookToken < Oauth2Token",
+#     :options => {
+#       :site => "https://graph.facebook.com"
+#     }
 #   },
 #   :agree2 => {
 #     :key => "",


### PR DESCRIPTION
The Facebook sample hash in the generator template is a little misleading. Here's a clearer example.
