### PR TITLE
OAuthFilter:oauth2_token to rejects headers that explicitly state oauth_version="1.0" 

### DIFF
--- a/lib/oauth/rack/oauth_filter.rb
+++ b/lib/oauth/rack/oauth_filter.rb
@@ -85,6 +85,7 @@ module OAuth
       def oauth2_token(request)
         (request.params["oauth_token"] && !request.params["oauth_signature"] ? request.params["oauth_token"] : nil )  ||
           request.env["HTTP_AUTHORIZATION"] &&
+          !request.env["HTTP_AUTHORIZATION"][/(oauth_version="1.0")/] &&
           request.env["HTTP_AUTHORIZATION"][/^(OAuth|Token) ([^\s]*)$/, 2]
       end
     end


### PR DESCRIPTION
Hi Pelle,

I've used your plugin in a couple of projects.  Thanks for this contribution!

In my most recent project (Rails3, using pre0.4) I ran into a problem where OAuth1 tokens where being mistaken as OAuth2 tokens.  I traced this to requests where there was no whitespace between the parameters in the HTTP_Authorization.  Requests with whitespace were correctly identified, requests without whitespace were not.

According to the standard (section 3.5.1 Authorization Header):
1.  Parameters are separated by a "," character (ASCII code 44) and
      OPTIONAL linear whitespace per [RFC2617].

OAuthFilter:oauth2_token was using this optional behavior to discriminate between oauth1 and oauth2 tokens.  While most OAuth clients put whitespace between their parameters, some clients do not.  The filter was mis-identifying these tokens as OAuth2 tokens, breaking the authentication chain.

I've added an explicit check for oauth_version="1.0".  If this is present, then the token is rejected.  

According to the standard (section 3.1. Making Requests):

```
   oauth_version
     OPTIONAL.  If present, MUST be set to "1.0".  Provides the
     version of the authentication process as defined in this
     specification.
```

When oauth_version is missing, oauth2_token defaults to checking for whitespace between the parameters.

In oauth_filter_spec I added a section (describe 'without optional whitespace') which creates authentication headers but without white space between the parameters.  As these are well formed requests (according to the standard) they should pass.  If you comment out the check (oauth_filter.rb , line 88) you will see that these properly formed requests fail.

Thanks again for a great plugin!  
