### PR TITLE
Generated migrations have the wrong column name for OauthToken#expires_at

### DIFF
--- a/generators/oauth_provider/templates/migration.rb
+++ b/generators/oauth_provider/templates/migration.rb
@@ -22,7 +22,7 @@ class CreateOauthTables < ActiveRecord::Migration
       t.string :callback_url
       t.string :verifier, :limit => 20
       t.string :scope
-      t.timestamp :authorized_at, :invalidated_at, :valid_to
+      t.timestamp :authorized_at, :invalidated_at, :expires_at
       t.timestamps
     end
     

--- a/lib/generators/active_record/oauth_provider_templates/migration.rb
+++ b/lib/generators/active_record/oauth_provider_templates/migration.rb
@@ -22,7 +22,7 @@ class CreateOauthTables < ActiveRecord::Migration
       t.string :callback_url
       t.string :verifier, :limit => 20
       t.string :scope
-      t.timestamp :authorized_at, :invalidated_at, :valid_to
+      t.timestamp :authorized_at, :invalidated_at, :expires_at
       t.timestamps
     end
 

--- a/lib/generators/mongoid/oauth_provider_templates/oauth_token.rb
+++ b/lib/generators/mongoid/oauth_provider_templates/oauth_token.rb
@@ -9,7 +9,7 @@ class OauthToken
   field :scope, :type => String
   field :authorized_at, :type => Time
   field :invalidated_at, :type => Time
-  field :valid_to, :type => Time
+  field :expires_at, :type => Time
 
   index :token, :unique => true
 


### PR DESCRIPTION
OauthToken expects a column named expires_at but the column was valid_to. This was changed in 0b2601ccf50dadeb6f0e1bc8e37273f9191cf2e3 but the migrations were never updated. Changed the field for mongoid too.
