### PR TITLE
Handle callbacks for OAuth 1.0 clients

### DIFF
--- a/lib/oauth/controllers/provider_controller.rb
+++ b/lib/oauth/controllers/provider_controller.rb
@@ -108,13 +108,20 @@ module OAuth
           if request.post?
             if user_authorizes_token?
               @token.authorize!(current_user)
-              callback_url  = @token.oob? ? @token.client_application.callback_url : @token.callback_url
+              if @token.oauth10?
+                callback_url = params[:oauth_callback] || @token.client_application.callback_url
+              else
+                callback_url = @token.oob? ? @token.client_application.callback_url : @token.callback_url
+              end
               @redirect_url = URI.parse(callback_url) unless callback_url.blank?
 
               unless @redirect_url.to_s.blank?
                 @redirect_url.query = @redirect_url.query.blank? ?
-                                      "oauth_token=#{@token.token}&oauth_verifier=#{@token.verifier}" :
-                                      @redirect_url.query + "&oauth_token=#{@token.token}&oauth_verifier=#{@token.verifier}"
+                                      "oauth_token=#{@token.token}" :
+                                      @redirect_url.query + "&oauth_token=#{@token.token}"
+                unless @token.oauth10?
+                  @redirect_url.query += "&oauth_verifier=#{@token.verifier}"
+                end
                 redirect_to @redirect_url.to_s
               else
                 render :action => "authorize_success"


### PR DESCRIPTION
The merging of the oauth1 and oauth2 providers in 810348163121c6e446b2a4946671c2d12c4ede5f accidentally lost the code which handled callbacks for 1.0 clients. This commit restores that support.
