### PR TITLE
update for latest version of oauth2 gem

### DIFF
--- a/lib/oauth/models/consumers/services/oauth2_token.rb
+++ b/lib/oauth/models/consumers/services/oauth2_token.rb
@@ -12,11 +12,11 @@ class Oauth2Token < ConsumerToken
   def self.authorize_url(callback_url)
     options = {:redirect_uri=>callback_url}
     options[:scope] = credentials[:scope] if credentials[:scope].present?
-    consumer.web_server.authorize_url(options)
+    consumer.auth_code.authorize_url(options)
   end
   
   def self.access_token(user, code, redirect_uri)
-    access_token = consumer.web_server.get_access_token(code, :redirect_uri => redirect_uri)
+    access_token = consumer.auth_code.get_token(code, :redirect_uri => redirect_uri)
     find_or_create_from_access_token user, access_token
   end
   

--- a/oauth-plugin.gemspec
+++ b/oauth-plugin.gemspec
@@ -34,6 +34,6 @@ Gem::Specification.new do |s|
   s.add_dependency "multi_json"
   s.add_dependency("oauth", ["~> 0.4.4"])
   s.add_dependency("rack")
-  s.add_dependency("oauth2")
+  s.add_dependency("oauth2", '>= 0.5.0')
 end
 


### PR DESCRIPTION
The latest oauth2 gem (0.5.0) renames some methods, this change makes the plugin compatible with the latest.
