### PR TITLE
Only accept valid OAuth 1 tokens

### DIFF
--- a/lib/oauth/rack/oauth_filter.rb
+++ b/lib/oauth/rack/oauth_filter.rb
@@ -40,7 +40,7 @@ module OAuth
             oauth_token = nil
 
             if request_proxy.token
-              oauth_token = client_application.tokens.first(:conditions => { :token => request_proxy.token })
+              oauth_token = client_application.tokens.first(:conditions => ['invalidated_at IS NULL AND authorized_at IS NOT NULL and token = ?', request_proxy.token])
               if oauth_token.respond_to?(:provided_oauth_verifier=)
                 oauth_token.provided_oauth_verifier = request_proxy.oauth_verifier
               end


### PR DESCRIPTION
This commit fixes the OAuth 1 token lookup to match the OAuth 2 lookup, so that only tokens which have (a) been authorised and (b) not been invalidated are accepted. 
