### PR TITLE
Fixes user creation with two fixes

### DIFF
--- a/lib/generators/active_record/oauth_consumer_templates/consumer_token.rb
+++ b/lib/generators/active_record/oauth_consumer_templates/consumer_token.rb
@@ -3,7 +3,7 @@ class ConsumerToken < ActiveRecord::Base
   include Oauth::Models::Consumers::Token
 
   # You can safely remove this callback if you don't allow login from any of your services
-  before_create :create_user
+  before_validation :create_user_if_create
 
   # Modify this with class_name etc to match your application
   belongs_to :user

--- a/lib/oauth/models/consumers/token.rb
+++ b/lib/oauth/models/consumers/token.rb
@@ -81,9 +81,14 @@ module Oauth
 
           def create_user
             self.user ||= begin
-              User.new params_for_user
+              user = User.new params_for_user
               user.save(:validate=>false)
+              user
             end
+          end
+
+          def create_user_if_create
+            create_user if id.nil?
           end
 
         end


### PR DESCRIPTION
1. Validation occurs before `before_create`.  To ensure `create_user` is called, it has to be done on `before_validation`.
2. `create_user` threw an error because `User.new` wasn't assigned to anything. After that, `user.save` would set `self.user` to `true`.
