### PR TITLE
Change to_a call to Array()

### DIFF
--- a/lib/oauth/controllers/application_controller_methods.rb
+++ b/lib/oauth/controllers/application_controller_methods.rb
@@ -43,7 +43,7 @@ module OAuth
         def allow?
           if @strategies.include?(:interactive) && interactive
             true
-          elsif !(@strategies & env["oauth.strategies"].to_a).empty?
+          elsif !(@strategies & Array(env["oauth.strategies"])).empty?
             @controller.send :current_user=, token.user if token
             true
           else


### PR DESCRIPTION
To get rid of deprecation warnings.
