### PR TITLE
persist refresh_token with OAuth2 models

### DIFF
--- a/generators/oauth_consumer/templates/migration.rb
+++ b/generators/oauth_consumer/templates/migration.rb
@@ -5,6 +5,7 @@ class CreateOauthConsumerTokens < ActiveRecord::Migration
       t.integer :user_id
       t.string :type, :limit => 30
       t.string :token, :limit => 1024 # This has to be huge because of Yahoo's excessively large tokens
+      t.string :refresh_token
       t.string :secret
       t.timestamps
     end

--- a/lib/oauth/models/consumers/token.rb
+++ b/lib/oauth/models/consumers/token.rb
@@ -39,14 +39,17 @@ module Oauth
           end
 
           def find_or_create_from_access_token(user,access_token)
-            secret = access_token.respond_to?(:secret) ? access_token.secret : nil
             if user
               token = self.find_or_initialize_by_user_id_and_token(user.id, access_token.token)
             else
               token = self.find_or_initialize_by_token(access_token.token)
             end
 
-            # set or update the secret
+            # set or update the secret and refresh_token
+            secret = access_token.respond_to?(:secret) ? access_token.secret : nil
+            refresh_token = access_token.respond_to?(:refresh_token) ? access_token.refresh_token : nil
+
+            token.refresh_token = refresh_token
             token.secret = secret
             token.save! if token.new_record? or token.changed?
 


### PR DESCRIPTION
Since this only checks for the `token`, the `refresh_token` is lost.  This pull request will persist the `refresh_token` if it's present.

THIS DOES NOT RESOLVE THE FULL PROBLEM....
OAuth2 supports refreshing a token, but oauth-plugin appears to not support this ability.  Without being able to refresh the access_token, authentication through OAuth2 is pretty useless.  What do you think is the best way to implement this?
