### PR TITLE
allow? should return false if no token is found

### DIFF
--- a/lib/oauth/controllers/application_controller_methods.rb
+++ b/lib/oauth/controllers/application_controller_methods.rb
@@ -44,8 +44,12 @@ module OAuth
           if @strategies.include?(:interactive) && interactive
             true
           elsif !(@strategies & env["oauth.strategies"].to_a).empty?
-            @controller.send :current_user=, token.user if token
-            true
+            if token.present?
+              @controller.send :current_user=, token.user
+              true
+            else
+              false
+            end
           else
             if @strategies.include?(:interactive)
               controller.send :access_denied


### PR DESCRIPTION
In application_controller_methods.rb:

Authenticator#allow? should return false if the token method returns nil.  

Currently it returns true but doesn't set current_user because of the if statement which will allow you to have access to the endpoint even if there isn't a token in the request header.
