### PR TITLE
OAuth 2.0 functionality and other fixes

### DIFF
--- a/generators/oauth_consumer/templates/migration.rb
+++ b/generators/oauth_consumer/templates/migration.rb
@@ -5,6 +5,7 @@ class CreateOauthConsumerTokens < ActiveRecord::Migration
       t.integer :user_id
       t.string :type, :limit => 30
       t.string :token, :limit => 1024 # This has to be huge because of Yahoo's excessively large tokens
+      t.string :refresh_token
       t.string :secret
       t.timestamps
     end

--- a/generators/oauth_consumer/templates/migration.rb
+++ b/generators/oauth_consumer/templates/migration.rb
@@ -6,6 +6,8 @@ class CreateOauthConsumerTokens < ActiveRecord::Migration
       t.string :type, :limit => 30
       t.string :token, :limit => 1024 # This has to be huge because of Yahoo's excessively large tokens
       t.string :refresh_token
+      t.string :expires_in
+      t.string :expires_at
       t.string :secret
       t.timestamps
     end

--- a/lib/oauth/controllers/application_controller_methods.rb
+++ b/lib/oauth/controllers/application_controller_methods.rb
@@ -44,8 +44,12 @@ module OAuth
           if @strategies.include?(:interactive) && interactive
             true
           elsif !(@strategies & env["oauth.strategies"].to_a).empty?
-            @controller.send :current_user=, token.user if token
-            true
+            if token.present?
+              @controller.send :current_user=, token.user
+              true
+            else
+              false
+            end
           else
             if @strategies.include?(:interactive)
               controller.send :access_denied

--- a/lib/oauth/controllers/consumer_controller.rb
+++ b/lib/oauth/controllers/consumer_controller.rb
@@ -25,7 +25,7 @@ module Oauth
 
         unless @token
           if @consumer.ancestors.include?(Oauth2Token)
-            request_url = callback2_oauth_consumer_url(params[:id]) + callback2_querystring
+            request_url = callback2_oauth_consumer_url + callback2_querystring
             redirect_to @consumer.authorize_url(request_url)
           else
             request_url = callback_oauth_consumer_url(params[:id]) + callback2_querystring
@@ -45,7 +45,7 @@ module Oauth
       end
       
       def callback2
-        @token = @consumer.access_token(current_user,params[:code], callback2_oauth_consumer_url(params[:id]))
+        @token = @consumer.access_token(current_user,params[:code], callback2_oauth_consumer_url)
         logger.info @token.inspect
         if @token
           # Log user in
@@ -116,6 +116,10 @@ module Oauth
 
           go_back
         end
+      end
+
+      def callback2_oauth_consumer_url
+        @consumer.consumer.options[:redirect_uri]
       end
 
       protected

--- a/lib/oauth/controllers/consumer_controller.rb
+++ b/lib/oauth/controllers/consumer_controller.rb
@@ -46,7 +46,6 @@ module Oauth
       
       def callback2
         @token = @consumer.access_token(current_user,params[:code], callback2_oauth_consumer_url)
-        logger.info @token.inspect
         if @token
           # Log user in
           if logged_in?

--- a/lib/oauth/models/consumers/services/oauth2_token.rb
+++ b/lib/oauth/models/consumers/services/oauth2_token.rb
@@ -1,5 +1,6 @@
 require 'oauth2'
 class Oauth2Token < ConsumerToken
+  after_initialize :ensure_access, if: :expired_and_existing?
 
   def self.consumer
     @consumer||=create_consumer
@@ -21,7 +22,28 @@ class Oauth2Token < ConsumerToken
   end
 
   def client
-    @client ||= OAuth2::AccessToken.new self.class.consumer, token
+    @client ||= OAuth2::AccessToken.new self.class.consumer, token, {refresh_token: refresh_token, expires_at: expires_at, expires_in: expires_in }
   end
 
+  # @return [Boolean] Is the access token expired and does the record exist in the datastore?
+  def expired_and_existing?
+    return true if !self.new_record? and Time.now.to_i >= self.expires_at.to_i
+    false
+  end
+
+  # Refreshes the access token to ensure access
+  def ensure_access
+    self.class.find_or_create_from_access_token user, self, client.refresh!
+  end
+
+  # Returns the expiration date (expires_in, expires_at)
+  #
+  # @return [String, String] Expires_in and expires_at, respectively
+  # @note It will return the default expiration time as defined in the OAuth 2.0 spec when no options are set
+  def expiration_date(token)
+    return token.expires_in, token.expires_at if !token.expires_in.nil? and !token.expires_at.nil?
+    return token.expires_in, (Time.now.to_i + token.expires_in.to_i) if token.expires_at.nil? and !token.expires_in.nil?
+    return (token.expires_at.to_i - Time.now.to_i), token.expires_at if token.expires_in.nil? and !token.expires_at.nil?
+    return "3600", (Time.now.to_i + 3600)
+  end
 end

--- a/lib/oauth/models/consumers/token.rb
+++ b/lib/oauth/models/consumers/token.rb
@@ -39,14 +39,17 @@ module Oauth
           end
 
           def find_or_create_from_access_token(user,access_token)
-            secret = access_token.respond_to?(:secret) ? access_token.secret : nil
             if user
               token = self.find_or_initialize_by_user_id_and_token(user.id, access_token.token)
             else
               token = self.find_or_initialize_by_token(access_token.token)
             end
 
-            # set or update the secret
+            # set or update the secret and refresh_token
+            secret = access_token.respond_to?(:secret) ? access_token.secret : nil
+            refresh_token = access_token.respond_to?(:refresh_token) ? access_token.refresh_token : nil
+
+            token.refresh_token = refresh_token
             token.secret = secret
             token.save! if token.new_record? or token.changed?
 

--- a/lib/oauth/models/consumers/token.rb
+++ b/lib/oauth/models/consumers/token.rb
@@ -72,6 +72,7 @@ module Oauth
             refresh_token = access_token.respond_to?(:refresh_token) ? access_token.refresh_token : nil
             expires_in, expires_at = token.expiration_date(access_token) if token.class.ancestors.include?(Oauth2Token)
 
+            token.token = access_token.token
             token.refresh_token = refresh_token
             token.secret = secret
             token.expires_at = expires_at

--- a/lib/oauth/models/consumers/token.rb
+++ b/lib/oauth/models/consumers/token.rb
@@ -38,20 +38,44 @@ module Oauth
             find_or_create_from_access_token user, access_token
           end
 
-          def find_or_create_from_access_token(user,access_token)
-            if user
-              token = self.find_or_initialize_by_user_id_and_token(user.id, access_token.token)
+          # Finds, creates or updates a ConsumerToken by finding the token
+          # or taking it when it's given. It then updates the attributes and saves the changes/new record to a datastore.
+          # @param user [User] The user to which the access token should belong to
+          # @param access_token [AccessToken || Oauth2Token] Either a request token taken from the service or a ConsumerToken
+          # @param new_token [AccessToken] A new access token, used for refreshing the access token with OAuth 2.
+          #
+          # Usage example:
+          # find_or_create_from_access_token(current_user, access_token) <-- Find or create a new access token
+          # find_or_create_from_access-token(current_user, Oauth2Token.last, client.refresh!) <-- Edits existing record with new refreshed information
+          def find_or_create_from_access_token(user, access_token, new_token = nil)
+            if access_token.class.ancestors.include?(Oauth2Token)
+              token = access_token
             else
-              token = self.find_or_initialize_by_token(access_token.token)
+              if user
+                token = self.find_or_initialize_by_user_id_and_token(user.id, access_token.token)
+              else
+                token = self.find_or_initialize_by_token(access_token.token)
+              end
             end
 
-            # set or update the secret and refresh_token
+            token = if new_token then set_details(new_token, access_token) else set_details(access_token, token) end
+
+            token.save! if token.new_record? or token.changed?
+
+            token
+          end
+
+          # Set the details such as the secret, refresh token and expiration time to an instance of ConsumerToken
+          # @return [ConsumerToken] A ConsumerToken
+          def set_details(access_token, token)
             secret = access_token.respond_to?(:secret) ? access_token.secret : nil
             refresh_token = access_token.respond_to?(:refresh_token) ? access_token.refresh_token : nil
+            expires_in, expires_at = token.expiration_date(access_token) if token.class.ancestors.include?(Oauth2Token)
 
             token.refresh_token = refresh_token
             token.secret = secret
-            token.save! if token.new_record? or token.changed?
+            token.expires_at = expires_at
+            token.expires_in = expires_in
 
             token
           end

--- a/lib/oauth/rack/oauth_filter.rb
+++ b/lib/oauth/rack/oauth_filter.rb
@@ -32,12 +32,14 @@ module OAuth
           end
 
         elsif oauth1_verify(request) do |request_proxy|
-            client_application = ClientApplication.find_by_key(request_proxy.consumer_key)
-            env["oauth.client_application_candidate"] = client_application
+          client_application = ClientApplication.find_by_key(request_proxy.consumer_key)
+          env["oauth.client_application_candidate"] = client_application
 
+          oauth_token = nil
+
+          if client_application
             # Store this temporarily in client_application object for use in request token generation
             client_application.token_callback_url = request_proxy.oauth_callback if request_proxy.oauth_callback
-            oauth_token = nil
 
             if request_proxy.token
               oauth_token = client_application.tokens.first(:conditions => ['invalidated_at IS NULL AND authorized_at IS NOT NULL and token = ?', request_proxy.token])
@@ -46,8 +48,10 @@ module OAuth
               end
               env["oauth.token_candidate"] = oauth_token
             end
-            # return the token secret and the consumer secret
-            [(oauth_token.nil? ? nil : oauth_token.secret), (client_application.nil? ? nil : client_application.secret)]
+          end
+
+          # return the token secret and the consumer secret
+          [(oauth_token.nil? ? nil : oauth_token.secret), (client_application.nil? ? nil : client_application.secret)]
         end
           if env["oauth.token_candidate"]
             env["oauth.token"] = env["oauth.token_candidate"]
@@ -84,9 +88,9 @@ module OAuth
 
       def oauth2_token(request)
         request.params['bearer_token'] || request.params['access_token'] || (request.params["oauth_token"] && !request.params["oauth_signature"] ? request.params["oauth_token"] : nil )  ||
-          request.env["HTTP_AUTHORIZATION"] &&
-          !request.env["HTTP_AUTHORIZATION"][/(oauth_version="1.0")/] &&
-          request.env["HTTP_AUTHORIZATION"][/^(Bearer|OAuth|Token) (token=)?([^\s]*)$/, 3]
+            request.env["HTTP_AUTHORIZATION"] &&
+                !request.env["HTTP_AUTHORIZATION"][/(oauth_version="1.0")/] &&
+                request.env["HTTP_AUTHORIZATION"][/^(Bearer|OAuth|Token) (token=)?([^\s]*)$/, 3]
       end
     end
   end

--- a/spec/dummy_provider_models.rb
+++ b/spec/dummy_provider_models.rb
@@ -20,7 +20,7 @@ class ClientApplication
 end
 
 class OauthToken
-  attr_accessor :token
+  attr_accessor :token, :refresh_token
 
   def self.first(conditions_hash)
     case conditions_hash[:conditions].last


### PR DESCRIPTION
I've noticed that this repository hasn't been touched in a while, and that it has never conformed to the OAuth 2.0 specs despite community efforts. That's why I took all the fixes that people have so generously commited as a pull request and combined them in my own fork. Thanks goes out to the following people for writing their fixes:
- pelle/oauth-plugin#132
- pelle/oauth-plugin#125
- @pelle for writing this gem.

The refreshing of the access token works as follows; once an access token has been acquired, [the expires_in and expires_at attributes will be set](https://github.com/RubenHoms/oauth-plugin/blob/feature/access-token-refresh/lib/oauth/models/consumers/token.rb#L50-66), if the consumer does not respond with such a paramter, the standard of 3600 seconds (1 hour) will be used and the object will be saved to the datastore. There's an [after_initialize callback](https://github.com/RubenHoms/oauth-plugin/blob/feature/access-token-refresh/lib/oauth/models/consumers/services/oauth2_token.rb#L3) on the `Oauth2Token` model which triggers only if the token has expired. If it does it will initialize the OAuth2 client and call the [refresh!](https://github.com/intridea/oauth2/blob/master/lib/oauth2/access_token.rb#L79-88) method. (thank you @greggroth for the pointer to this method) It will then save the new attributes to the datastore.

I'm pretty sure that the `after_initialize` is the way to go since most expirations are set to 3600 seconds and the object will be initialized many times in between. If anyone would know of a more clean way of doing this, please say you and I will try to fix it.

Here's an example of how to add Skydrive as an OAuth 2.0 provider in the oauth_consumers.rb file:

``` ruby
OAUTH_CREDENTIALS={
  skydrive: {
    key: "YourKeyHere",
    secret: "YourSecretHere",
    super_class: "Oauth2Token", # Use this or override this for OAuth 2.0 consumers
    scope: "wl.basic wl.emails wl.skydrive_update wl.offline_access",
    options: {
      site: "https://login.live.com",
      token_url: "/oauth20_token.srf",
      authorize_url: "/oauth20_authorize.srf",
      response_type: "code",
      client_id: 'YourClientIdHere',
      redirect_uri: 'http://www.yourwebsite.com/oauth_consumers/skydrive/callback2' # Required for OAuth 2.0 providers!
    }
  }
}
```

Note that the redirect_uri option is required for the callback. Your routes.rb file should look something like this to make this work:

``` ruby
resources :oauth_consumers do
  get :callback, :on => :member
  get :callback2, :on => :member # Add this line for OAuth 2.0 functionality.
end
```
