### PR TITLE
Allow users to only apply the middleware to specific paths

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -138,6 +138,11 @@ A big change over previous versions is that we now use a rack filter. You have t
   require 'oauth/rack/oauth_filter'
   config.middleware.use OAuth::Rack::OAuthFilter
 
+== Filter Options
+If you only want the middleware to operate on certain paths, you can supply a regex expression to whitelist certain paths.
+
+  require 'oauth/rack/oauth_filter'
+  config.middleware.use OAuth::Rack::OAuthFilter, '\/api\/*'
 
 === Generator Options
 

--- a/oauth-plugin.gemspec
+++ b/oauth-plugin.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rack-test"
 
   s.add_dependency "multi_json"
-  s.add_dependency("oauth", ["~> 0.4.4"])
+  s.add_dependency("oauth", ["~> 0.5.3"])
   s.add_dependency("rack")
   s.add_dependency("oauth2", '>= 0.5.0')
 end

--- a/spec/rack/oauth_filter_spec.rb
+++ b/spec/rack/oauth_filter_spec.rb
@@ -30,6 +30,14 @@ describe OAuth::Rack::OAuthFilter do
     response.should == {}
   end
 
+  it "should pass through when not on the whitelisted paths" do
+    @app ||= OAuth::Rack::OAuthFilter.new(OAuthEcho.new, '\/api/')
+    get '/',{},{"HTTP_AUTHORIZATION"=>'OAuth oauth_consumer_key="my_consumer", oauth_nonce="amrLDyFE2AMztx5fOYDD1OEqWps6Mc2mAR5qyO44Rj8", oauth_signature="KCSg0RUfVFUcyhrgJo580H8ey0c%3D", oauth_signature_method="HMAC-SHA1", oauth_timestamp="1295039581", oauth_version="1.0"'}
+    last_response.should be_ok
+    response = MultiJson.decode(last_response.body)
+    response.should == {}
+  end
+
   describe 'OAuth1' do
     describe 'with optional white space' do
       it "should sign with consumer" do


### PR DESCRIPTION
I have added an optional param to the middleware definition.  The user can specify a regex to restrict the paths that the OAuthFilter will act upon.  If no param is supplied, the OAuthFilter will operate on all URLs (the current functionality is the default).
