### PR TITLE
Set content type "application/x-www-form-urlencoded" when returning tokens to client

### DIFF
--- a/lib/oauth/controllers/provider_controller.rb
+++ b/lib/oauth/controllers/provider_controller.rb
@@ -17,7 +17,7 @@ module OAuth
       def request_token
         @token = current_client_application.create_request_token params
         if @token
-          render :text => @token.to_query
+          render :text => @token.to_query, :content_type => "application/x-www-form-urlencoded"
         else
           render :nothing => true, :status => 401
         end
@@ -26,7 +26,7 @@ module OAuth
       def access_token
         @token = current_token && current_token.exchange!
         if @token
-          render :text => @token.to_query
+          render :text => @token.to_query, :content_type => "application/x-www-form-urlencoded"
         else
           render :nothing => true, :status => 401
         end


### PR DESCRIPTION
https://tools.ietf.org/html/rfc5849#page-9

RFC 5849 requires or at least strongly suggests that tokens be returned with content type "application/x-www-form-urlencoded"

From Section 2.1:
"The server MUST verify (Section 3.2) the request and if valid,
   respond back to the client with a set of temporary credentials (in
   the form of an identifier and shared-secret).  The temporary
   credentials are included in the HTTP response body using the
   "application/x-www-form-urlencoded" content type as defined by
   [W3C.REC-html40-19980424] with a 200 status code (OK)."

I believe the MUST applies to the 2nd sentence as well.  The first sentence declares the server MUST respond with temporary credentials.  The 2nd sentence goes on to clarify that the credentials "are included in the HTTP response body using the "application/x-www-form-urlencoded" content type"

Additionally, every example given in the RFC uses "application/x-www-form-urlencoded"

oauth-plugin currently returns content type "text/plain".  This causes a problem in clients who enforce strict adherence to the RFC's content-type "application/x-www-form-urlencoded"

NB:  I'm not a rails developer.  I discovered this when working with the Qt Framework OAuth1 client.  The code changes in this PR have not been tested.
