### PR TITLE
Update application_controller_methods.rb

### DIFF
--- a/lib/oauth/controllers/application_controller_methods.rb
+++ b/lib/oauth/controllers/application_controller_methods.rb
@@ -126,7 +126,7 @@ module OAuth
       end
 
       def invalid_oauth_response(code=401,message="Invalid OAuth Request")
-        render :text => message, :status => code
+        render :plain => message, :status => code
         false
       end
 


### PR DESCRIPTION
`render :text` is deprecated on rails 5